### PR TITLE
Another approach to multiple media servers (media_servers parameter)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ else
   gem 'puppet', :require => false
 end
 
-gem 'puppetlabs_spec_helper', '>= 1.2.0', :require => false
 gem 'facter', '>= 1.7.0', :require => false
 gem 'rspec-puppet', :require => false
 gem 'puppet-lint', '~> 2.0', :require => false
@@ -22,9 +21,11 @@ gem 'puppet-lint-undef_in_function-check', :require => false
 gem 'puppet-lint-unquoted_string-check', :require => false
 gem 'puppet-lint-variable_contains_upcase', :require => false
 
-gem 'rspec',              '~> 2.0',   :require => false if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
-gem 'rake',               '~> 10.0',  :require => false if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
-gem 'json',               '<= 1.8',   :require => false if RUBY_VERSION < '2.0.0'
-gem 'json_pure',          '<= 2.0.1', :require => false if RUBY_VERSION < '2.0.0'
-gem 'metadata-json-lint', '0.0.11',   :require => false if RUBY_VERSION < '1.9'
-gem 'metadata-json-lint',             :require => false if RUBY_VERSION >= '1.9'
+gem 'rspec',                  '~> 2.0',   :require => false if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
+gem 'rake',                   '~> 10.0',  :require => false if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
+gem 'json',                   '<= 1.8',   :require => false if RUBY_VERSION < '2.0.0'
+gem 'json_pure',              '<= 2.0.1', :require => false if RUBY_VERSION < '2.0.0'
+gem 'metadata-json-lint',     '0.0.11',   :require => false if RUBY_VERSION < '1.9'
+gem 'metadata-json-lint',                 :require => false if RUBY_VERSION >= '1.9'
+gem 'puppetlabs_spec_helper', '< 2.0',    :require => false if RUBY_VERSION < '1.9'
+gem 'puppetlabs_spec_helper', '>= 1.2.0', :require => false if RUBY_VERSION >= '1.9'

--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ Hostname of NetBackup Media Server
 
 - *Default*: undef
 
+media_servers
+------------
+Array of hostnames of NetBackup Media Servers
+
+- *Default*: []
+
 nb_lib_path
 -----------
 path where netbackup libs are stored

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -18,6 +18,7 @@ class netbackup::client(
   $nb_bin_path                  = '/usr/openv/netbackup/bin',
   $server                       = "netbackup.${::domain}",
   $media_server                 = undef,
+  $media_servers                = [],
   $symcnbclt_package_source     = '/var/tmp/nbclient/SYMCnbclt.pkg',
   $symcnbclt_package_adminfile  = '/var/tmp/nbclient/admin',
   $symcnbjava_package_source    = '/var/tmp/nbclient/SYMCnbjava.pkg',

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -435,6 +435,18 @@ describe 'netbackup::client' do
       it { should contain_file('bp_config').with_content(/^MEDIA_SERVER = my_media_server$/) }
     end
 
+    context 'where media_servers is set to a valid value' do
+      let :params do
+        {
+          :media_servers => [ 'my_media_server_1', 'my_media_server_2' ],
+        }
+      end
+
+      it {
+        should contain_file('bp_config').with_content(/^MEDIA_SERVER = my_media_server_1$/) 
+        should contain_file('bp_config').with_content(/^MEDIA_SERVER = my_media_server_2$/) 
+      }
+    end
 
     context 'where nb_lib_new_file and nb_lib_path are set to valid values' do
       let :params do

--- a/templates/bp.conf.erb
+++ b/templates/bp.conf.erb
@@ -5,3 +5,6 @@ CLIENT_NAME = <%= @client_name %>
 <% if @media_server -%>
 MEDIA_SERVER = <%= @media_server %>
 <%- end %>
+<% @media_servers.each do |media_server| %>
+MEDIA_SERVER = <%= media_server %>
+<% end %>


### PR DESCRIPTION
Like #23 and #18, this allows you to configure multiple media servers by adding them as an array.

You could also combine a single media server with an array if desired.

This seems to be the most compatible approach.