### PR TITLE
Update testing rig

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ env:
     - PUPPET_GEM_VERSION="~> 4.7.0"
     - PUPPET_GEM_VERSION="~> 4.8.0"
     - PUPPET_GEM_VERSION="~> 4.9.0"
+    - PUPPET_GEM_VERSION="~> 4.10.0"
     - PUPPET_GEM_VERSION="~> 4"
 
 sudo: false
@@ -72,6 +73,12 @@ matrix:
       env: PUPPET_GEM_VERSION="~> 4.9.0"
     - rvm: 2.0.0
       env: PUPPET_GEM_VERSION="~> 4.9.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.10.0"
+    - rvm: 1.9.3
+      env: PUPPET_GEM_VERSION="~> 4.10.0"
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 4.10.0"
     - rvm: 1.8.7
       env: PUPPET_GEM_VERSION="~> 4"
     - rvm: 1.9.3

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ else
   gem 'puppet', :require => false
 end
 
-gem 'puppetlabs_spec_helper', '>= 1.2.0', :require => false
 gem 'facter', '>= 1.7.0', :require => false
 gem 'rspec-puppet', :require => false
 gem 'puppet-lint', '~> 2.0', :require => false
@@ -28,3 +27,8 @@ gem 'json',               '<= 1.8',   :require => false if RUBY_VERSION < '2.0.0
 gem 'json_pure',          '<= 2.0.1', :require => false if RUBY_VERSION < '2.0.0'
 gem 'metadata-json-lint', '0.0.11',   :require => false if RUBY_VERSION < '1.9'
 gem 'metadata-json-lint',             :require => false if RUBY_VERSION >= '1.9'
+
+# Puppetlabs is dropping support for Ruby 1.8.7 in latests releases, pin to last supported version when running on Ruby 1.8.7
+gem 'puppetlabs_spec_helper', '2.0.2',    :require => false if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
+gem 'puppetlabs_spec_helper', '>= 2.0.0', :require => false if RUBY_VERSION >= '1.9'
+gem 'parallel_tests',         '<= 2.9.0', :require => false if RUBY_VERSION < '2.0.0'

--- a/Rakefile
+++ b/Rakefile
@@ -4,15 +4,15 @@ require 'puppet-lint/tasks/puppet-lint'
 PuppetLint.configuration.send('disable_80chars')
 PuppetLint.configuration.send('disable_140chars')
 PuppetLint.configuration.relative = true
-PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
+PuppetLint.configuration.ignore_paths = ['spec/**/*.pp', 'pkg/**/*.pp']
 
 desc 'Validate manifests, templates, and ruby files'
 task :validate do
   Dir['manifests/**/*.pp'].each do |manifest|
     sh "puppet parser validate --noop #{manifest}"
   end
-  Dir['spec/**/*.rb','lib/**/*.rb'].each do |ruby_file|
-    sh "ruby -c #{ruby_file}" unless ruby_file =~ /spec\/fixtures/
+  Dir['spec/**/*.rb', 'lib/**/*.rb'].each do |ruby_file|
+    sh "ruby -c #{ruby_file}" unless ruby_file =~ %r{/spec/fixtures}
   end
   Dir['templates/**/*.erb'].each do |template|
     sh "erb -P -x -T '-' #{template} | ruby -c"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,16 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
+
+RSpec.configure do |config|
+  config.hiera_config = 'spec/fixtures/hiera/hiera.yaml'
+  config.before :each do
+    # Ensure that we don't accidentally cache facts and environment between
+    # test cases.  This requires each example group to explicitly load the
+    # facts being exercised with something like
+    # Facter.collection.loader.load(:ipaddress)
+    Facter.clear
+    Facter.clear_messages
+  end
+  config.default_facts = {
+    :environment => 'rp_env',
+  }
+end


### PR DESCRIPTION
- Support Puppet >= 4.10.0
- keep support for Ruby 1.8.7