### PR TITLE
Add support for multiple Media Servers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,34 +1,35 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
-if ENV['PUPPET_GEM_VERSION']
-  gem 'puppet', ENV['PUPPET_GEM_VERSION'], :require => false
+if puppetversion = ENV['PUPPET_GEM_VERSION']
+  gem 'puppet', puppetversion, :require => false
 else
   gem 'puppet', :require => false
 end
 
-gem 'facter', '>= 1.7.0', :require => false
-gem 'rspec-puppet', :require => false
-gem 'puppet-lint', '~> 2.0', :require => false
-gem 'puppet-lint-absolute_classname-check', :require => false
-gem 'puppet-lint-alias-check', :require => false
-gem 'puppet-lint-empty_string-check', :require => false
-gem 'puppet-lint-file_ensure-check', :require => false
-gem 'puppet-lint-file_source_rights-check', :require => false
-gem 'puppet-lint-leading_zero-check', :require => false
-gem 'puppet-lint-spaceship_operator_without_tag-check', :require => false
-gem 'puppet-lint-trailing_comma-check', :require => false
-gem 'puppet-lint-undef_in_function-check', :require => false
-gem 'puppet-lint-unquoted_string-check', :require => false
-gem 'puppet-lint-variable_contains_upcase', :require => false
+gem 'facter', '>= 1.7.0'
+gem 'puppet-lint', '~> 2.0'
+gem 'puppet-lint-absolute_classname-check'
+gem 'puppet-lint-alias-check'
+gem 'puppet-lint-empty_string-check'
+gem 'puppet-lint-file_ensure-check'
+gem 'puppet-lint-file_source_rights-check'
+gem 'puppet-lint-leading_zero-check'
+gem 'puppet-lint-spaceship_operator_without_tag-check'
+gem 'puppet-lint-trailing_comma-check'
+gem 'puppet-lint-undef_in_function-check'
+gem 'puppet-lint-unquoted_string-check'
+gem 'puppet-lint-variable_contains_upcase'
+gem 'rspec-puppet', '~> 2.5.0'
 
-gem 'rspec',              '~> 2.0',   :require => false if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
-gem 'rake',               '~> 10.0',  :require => false if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
-gem 'json',               '<= 1.8',   :require => false if RUBY_VERSION < '2.0.0'
-gem 'json_pure',          '<= 2.0.1', :require => false if RUBY_VERSION < '2.0.0'
-gem 'metadata-json-lint', '0.0.11',   :require => false if RUBY_VERSION < '1.9'
-gem 'metadata-json-lint',             :require => false if RUBY_VERSION >= '1.9'
+gem 'json',                   '<= 1.8'   if RUBY_VERSION < '2.0.0'
+gem 'json_pure',              '<= 2.0.1' if RUBY_VERSION < '2.0.0'
+gem 'metadata-json-lint',     '0.0.11'   if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
+gem 'metadata-json-lint',     '1.0.0'    if RUBY_VERSION >= '1.9' && RUBY_VERSION < '2.0'
+gem 'metadata-json-lint'                 if RUBY_VERSION >= '2.0'
+gem 'parallel_tests',         '<= 2.9.0' if RUBY_VERSION > '1.9.3' # [1]
+gem 'puppetlabs_spec_helper', '2.0.2'    if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9' # [1]
+gem 'puppetlabs_spec_helper', '>= 2.0.0' if RUBY_VERSION >= '1.9' # [1]
+gem 'rake',                   '~> 10.0'  if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
+gem 'rspec',                  '~> 2.0'   if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
 
-# Puppetlabs is dropping support for Ruby 1.8.7 in latests releases, pin to last supported version when running on Ruby 1.8.7
-gem 'puppetlabs_spec_helper', '2.0.2',    :require => false if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
-gem 'puppetlabs_spec_helper', '>= 2.0.0', :require => false if RUBY_VERSION >= '1.9'
-gem 'parallel_tests',         '<= 2.9.0', :require => false if RUBY_VERSION < '2.0.0'
+# [1] Puppetlabs is dropping support for Ruby 1.8.7 in latests releases, pin to last supported version when running on Ruby 1.8.7

--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ init script source
 
 - *Default*: /usr/openv/netbackup/bin/goodies/netbackup
 
-media_server
+media_server (array)
 ------------
-Hostname of NetBackup Media Server
+Array of hostname(s) of NetBackup Media Servers. Support for strings is provided for backward compatibility and migration only and will be deprecated soon.
 
-- *Default*: undef
+- *Default*: []
 
 nb_lib_path
 -----------

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -17,7 +17,7 @@ class netbackup::client(
   $nb_bin_new_file              = '/usr/openv/netbackup/bin/bpcd_new',
   $nb_bin_path                  = '/usr/openv/netbackup/bin',
   $server                       = "netbackup.${::domain}",
-  $media_server                 = undef,
+  $media_server                 = [],
   $symcnbclt_package_source     = '/var/tmp/nbclient/SYMCnbclt.pkg',
   $symcnbclt_package_adminfile  = '/var/tmp/nbclient/admin',
   $symcnbjava_package_source    = '/var/tmp/nbclient/SYMCnbjava.pkg',
@@ -113,6 +113,13 @@ class netbackup::client(
     }
     default: {
       fail("netbackup::client is supported on osfamily RedHat, SuSE and Solaris. Your osfamily is identified as ${::osfamily}")
+    }
+  }
+
+  case type3x($media_server) {
+    'array':  { $media_server_array = $media_server  }
+    'string': { $media_server_array = any2array($media_server) }
+    default:  { fail('netbackup::media_server must be an array or string.')
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -9,6 +9,6 @@
   "issues_url": "https://github.com/Ericsson/puppet-module-netbackup/issues",
   "tags": ["netbackup","backup"],
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">=4.6.0" }
+    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.6.0 < 6.0.0" }
   ]
 }

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -441,7 +441,17 @@ describe 'netbackup::client' do
       }
     end
 
-    context 'where media_server is set to a valid value' do
+    context 'where media_server is set to a valid array' do
+      let :params do
+        {
+          :media_server => [ 'my_media_server_1', 'my_media_server_2' ],
+        }
+      end
+
+      it { should contain_file('bp_config').with_content(/^MEDIA_SERVER = my_media_server_1\nMEDIA_SERVER = my_media_server_2$/) }
+    end
+
+    context 'where media_server is set to a valid string' do
       let :params do
         {
           :media_server => 'my_media_server',
@@ -450,7 +460,6 @@ describe 'netbackup::client' do
 
       it { should contain_file('bp_config').with_content(/^MEDIA_SERVER = my_media_server$/) }
     end
-
 
     context 'where nb_lib_new_file and nb_lib_path are set to valid values' do
       let :params do

--- a/templates/bp.conf.erb
+++ b/templates/bp.conf.erb
@@ -2,6 +2,6 @@
 # DO NOT EDIT
 SERVER = <%= @server %>
 CLIENT_NAME = <%= @client_name %>
-<% if @media_server -%>
-MEDIA_SERVER = <%= @media_server %>
-<%- end %>
+<% @media_server_array.each do |media_server| -%>
+MEDIA_SERVER = <%= media_server %>
+<% end %>


### PR DESCRIPTION
$media_server does now support arrays to specify multiple media servers.
For backward compatibility strings will be converted to an arrray.