### PR TITLE
Adding 2 variables to disable ctime and atime during backups

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,6 +2,6 @@ fixtures:
   repositories:
     'stdlib':
       repo: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
-      ref: '4.6.0'
+      ref: '4.10.0'
   symlinks:
     'netbackup': "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -99,6 +99,19 @@ Array of hostname(s) of NetBackup Media Servers. Support for strings is provided
 
 - *Default*: []
 
+do_not_reset_file_access_time (bool)
+------------
+Boolean to chose if netbackup should change the access time on backuped files. The bool is translated to YES or NO in the conf file. When left undefined, nothing will be added to the conf file. The application will use it's own internal default value of NO (at the time of writing).
+
+
+- *Default*: undef
+
+use_ctime_for_incrementals (bool)
+------------
+Boolean to chose if netbackup should change the change time on backuped files. The bool is translated to YES or NO in the conf file. When left undefined, nothing will be added to the conf file. The application will use it's own internal default value of NO (at the time of writing).
+
+- *Default*: undef
+
 nb_lib_path
 -----------
 path where netbackup libs are stored

--- a/README.md
+++ b/README.md
@@ -101,16 +101,15 @@ Array of hostname(s) of NetBackup Media Servers. Support for strings is provided
 
 do_not_reset_file_access_time (bool)
 ------------
-Boolean to chose if netbackup should change the access time on backuped files. The bool is translated to YES or NO in the conf file. When left undefined, nothing will be added to the conf file. The application will use it's own internal default value of NO (at the time of writing).
+Boolean to chose if netbackup should change the access time on backuped files. The bool is translated to YES or NO in the conf file.
 
-
-- *Default*: undef
+- *Default*: false
 
 use_ctime_for_incrementals (bool)
 ------------
-Boolean to chose if netbackup should change the change time on backuped files. The bool is translated to YES or NO in the conf file. When left undefined, nothing will be added to the conf file. The application will use it's own internal default value of NO (at the time of writing).
+Boolean to chose if netbackup should change the change time on backuped files. The bool is translated to YES or NO in the conf file.
 
-- *Default*: undef
+- *Default*: false
 
 nb_lib_path
 -----------

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -18,8 +18,8 @@ class netbackup::client(
   $nb_bin_path                   = '/usr/openv/netbackup/bin',
   $server                        = "netbackup.${::domain}",
   $media_server                  = [],
-  $do_not_reset_file_access_time = undef,
-  $use_ctime_for_incrementals    = undef,
+  $do_not_reset_file_access_time = false,
+  $use_ctime_for_incrementals    = false,
   $symcnbclt_package_source      = '/var/tmp/nbclient/SYMCnbclt.pkg',
   $symcnbclt_package_adminfile   = '/var/tmp/nbclient/admin',
   $symcnbjava_package_source     = '/var/tmp/nbclient/SYMCnbjava.pkg',
@@ -125,16 +125,8 @@ class netbackup::client(
     }
   }
 
-  $do_not_reset_file_access_time_bool = str2bool($do_not_reset_file_access_time)
-  $use_ctime_for_incrementals_bool    = str2bool($use_ctime_for_incrementals)
-
-  validate_bool(
-    $do_not_reset_file_access_time_bool,
-    $use_ctime_for_incrementals_bool,
-  )
-
-  $do_not_reset_file_access_time_string = bool2str($do_not_reset_file_access_time_bool, 'YES', 'NO')
-  $use_ctime_for_incrementals_string    = bool2str($use_ctime_for_incrementals_bool, 'YES', 'NO')
+  $do_not_reset_file_access_time_string = bool2str(str2bool($do_not_reset_file_access_time), 'YES', 'NO')
+  $use_ctime_for_incrementals_string    = bool2str(str2bool($use_ctime_for_incrementals), 'YES', 'NO')
 
   # Solaris specific workarounds
   # $my_client_packages is needed on Solaris for dependencies checks only, not for package selection.

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,35 +1,37 @@
 # == Class: netbackup::client
 #
 class netbackup::client(
-  $bp_config_path               = '/usr/openv/netbackup/bp.conf',
-  $bp_config_owner              = 'root',
-  $bp_config_group              = 'bin',
-  $bp_config_mode               = '0644',
-  $client_name                  = $::hostname,
-  $client_packages              = undef,
-  $init_script_path             = undef,
-  $init_script_owner            = 'root',
-  $init_script_group            = 'root',
-  $init_script_mode             = '0755',
-  $init_script_source           = '/usr/openv/netbackup/bin/goodies/netbackup',
-  $nb_lib_new_file              = '/usr/openv/lib/libnbbaseST.so_new',
-  $nb_lib_path                  = '/usr/openv/lib',
-  $nb_bin_new_file              = '/usr/openv/netbackup/bin/bpcd_new',
-  $nb_bin_path                  = '/usr/openv/netbackup/bin',
-  $server                       = "netbackup.${::domain}",
-  $media_server                 = [],
-  $symcnbclt_package_source     = '/var/tmp/nbclient/SYMCnbclt.pkg',
-  $symcnbclt_package_adminfile  = '/var/tmp/nbclient/admin',
-  $symcnbjava_package_source    = '/var/tmp/nbclient/SYMCnbjava.pkg',
-  $symcnbjava_package_adminfile = '/var/tmp/nbclient/admin',
-  $symcnbjre_package_source     = '/var/tmp/nbclient/SYMCnbjre.pkg',
-  $symcnbjre_package_adminfile  = '/var/tmp/nbclient/admin',
-  $symcpddea_package_source     = '/var/tmp/nbclient/SYMCpddea.pkg',
-  $symcpddea_package_adminfile  = '/var/tmp/nbclient/admin',
-  $vrtspbx_package_source       = '/var/tmp/nbclient/VRTSpbx.pkg',
-  $vrtspbx_package_adminfile    = '/var/tmp/nbclient/admin',
-  $nbtar_package_source         = '/var/tmp/nbclient/nbtar.pkg',
-  $nbtar_package_adminfile      = '/var/tmp/nbclient/admin',
+  $bp_config_path                = '/usr/openv/netbackup/bp.conf',
+  $bp_config_owner               = 'root',
+  $bp_config_group               = 'bin',
+  $bp_config_mode                = '0644',
+  $client_name                   = $::hostname,
+  $client_packages               = undef,
+  $init_script_path              = undef,
+  $init_script_owner             = 'root',
+  $init_script_group             = 'root',
+  $init_script_mode              = '0755',
+  $init_script_source            = '/usr/openv/netbackup/bin/goodies/netbackup',
+  $nb_lib_new_file               = '/usr/openv/lib/libnbbaseST.so_new',
+  $nb_lib_path                   = '/usr/openv/lib',
+  $nb_bin_new_file               = '/usr/openv/netbackup/bin/bpcd_new',
+  $nb_bin_path                   = '/usr/openv/netbackup/bin',
+  $server                        = "netbackup.${::domain}",
+  $media_server                  = [],
+  $do_not_reset_file_access_time = undef,
+  $use_ctime_for_incrementals    = undef,
+  $symcnbclt_package_source      = '/var/tmp/nbclient/SYMCnbclt.pkg',
+  $symcnbclt_package_adminfile   = '/var/tmp/nbclient/admin',
+  $symcnbjava_package_source     = '/var/tmp/nbclient/SYMCnbjava.pkg',
+  $symcnbjava_package_adminfile  = '/var/tmp/nbclient/admin',
+  $symcnbjre_package_source      = '/var/tmp/nbclient/SYMCnbjre.pkg',
+  $symcnbjre_package_adminfile   = '/var/tmp/nbclient/admin',
+  $symcpddea_package_source      = '/var/tmp/nbclient/SYMCpddea.pkg',
+  $symcpddea_package_adminfile   = '/var/tmp/nbclient/admin',
+  $vrtspbx_package_source        = '/var/tmp/nbclient/VRTSpbx.pkg',
+  $vrtspbx_package_adminfile     = '/var/tmp/nbclient/admin',
+  $nbtar_package_source          = '/var/tmp/nbclient/nbtar.pkg',
+  $nbtar_package_adminfile       = '/var/tmp/nbclient/admin',
 ) {
 
   case $::osfamily {
@@ -122,6 +124,17 @@ class netbackup::client(
     default:  { fail('netbackup::media_server must be an array or string.')
     }
   }
+
+  $do_not_reset_file_access_time_bool = str2bool($do_not_reset_file_access_time)
+  $use_ctime_for_incrementals_bool    = str2bool($use_ctime_for_incrementals)
+
+  validate_bool(
+    $do_not_reset_file_access_time_bool,
+    $use_ctime_for_incrementals_bool,
+  )
+
+  $do_not_reset_file_access_time_string = bool2str($do_not_reset_file_access_time_bool, 'YES', 'NO')
+  $use_ctime_for_incrementals_string    = bool2str($use_ctime_for_incrementals_bool, 'YES', 'NO')
 
   # Solaris specific workarounds
   # $my_client_packages is needed on Solaris for dependencies checks only, not for package selection.

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -205,6 +205,8 @@ describe 'netbackup::client' do
         end
         it { should contain_file('bp_config').with_content(/^SERVER = netbackup.example.com$/) }
         it { should contain_file('bp_config').with_content(/^CLIENT_NAME = host$/) }
+        it { should contain_file('bp_config').without_content(%r{^DO_NOT_RESET_FILE_ACCESS_TIME.*$}) }
+        it { should contain_file('bp_config').without_content(%r{^USE_CTIME_FOR_INCREMENTALS.*$}) }
 
         it do
           should contain_file('init_script').with({
@@ -493,5 +495,37 @@ describe 'netbackup::client' do
       end
     end
 
+    context 'where do_not_reset_file_access_time are set to invalid values' do
+      let :params do
+        {
+          :do_not_reset_file_access_time => 'foo',
+        }
+      end
+      it 'should fail' do
+        expect {
+          should contain_class('netbackup::client')
+          }.to raise_error(Puppet::Error)
+      end
+    end
+    context 'where use_ctime_for_incrementals are set to invalid values' do
+      let :params do
+        {
+          :use_ctime_for_incrementals => 'bar',
+        }
+      end
+      it 'should fail' do
+        expect {
+          should contain_class('netbackup::client')
+          }.to raise_error(Puppet::Error)
+      end
+    end
+    context 'when do_not_reset_file_access_time set to valid true' do
+      let(:params) { { :do_not_reset_file_access_time => true } }
+      it { should contain_file('bp_config').with_content(%r{^DO_NOT_RESET_FILE_ACCESS_TIME = YES$}) }
+    end
+    context 'when use_ctime_for_incrementals set to valid true' do
+      let(:params) { { :use_ctime_for_incrementals => true } }
+      it { should contain_file('bp_config').with_content(%r{^USE_CTIME_FOR_INCREMENTALS = YES$}) }
+    end
   end
 end

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -205,8 +205,8 @@ describe 'netbackup::client' do
         end
         it { should contain_file('bp_config').with_content(/^SERVER = netbackup.example.com$/) }
         it { should contain_file('bp_config').with_content(/^CLIENT_NAME = host$/) }
-        it { should contain_file('bp_config').without_content(%r{^DO_NOT_RESET_FILE_ACCESS_TIME.*$}) }
-        it { should contain_file('bp_config').without_content(%r{^USE_CTIME_FOR_INCREMENTALS.*$}) }
+        it { should contain_file('bp_config').with_content(%r{^DO_NOT_RESET_FILE_ACCESS_TIME = NO$}) }
+        it { should contain_file('bp_config').with_content(%r{^USE_CTIME_FOR_INCREMENTALS = NO$}) }
 
         it do
           should contain_file('init_script').with({
@@ -327,14 +327,6 @@ describe 'netbackup::client' do
   end
 
   describe 'with osfamily independend parameters specified' do
-    let :facts do
-      {
-        :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-        :architecture      => 'x86_64',
-      }
-    end
-
     context 'where bp_config_path/_owner/_group/_mode are set to valid values' do
       let :params do
         {
@@ -495,37 +487,47 @@ describe 'netbackup::client' do
       end
     end
 
-    context 'where do_not_reset_file_access_time are set to invalid values' do
-      let :params do
-        {
-          :do_not_reset_file_access_time => 'foo',
-        }
-      end
-      it 'should fail' do
-        expect {
-          should contain_class('netbackup::client')
-          }.to raise_error(Puppet::Error)
-      end
-    end
-    context 'where use_ctime_for_incrementals are set to invalid values' do
-      let :params do
-        {
-          :use_ctime_for_incrementals => 'bar',
-        }
-      end
-      it 'should fail' do
-        expect {
-          should contain_class('netbackup::client')
-          }.to raise_error(Puppet::Error)
-      end
-    end
     context 'when do_not_reset_file_access_time set to valid true' do
       let(:params) { { :do_not_reset_file_access_time => true } }
       it { should contain_file('bp_config').with_content(%r{^DO_NOT_RESET_FILE_ACCESS_TIME = YES$}) }
     end
+
     context 'when use_ctime_for_incrementals set to valid true' do
       let(:params) { { :use_ctime_for_incrementals => true } }
       it { should contain_file('bp_config').with_content(%r{^USE_CTIME_FOR_INCREMENTALS = YES$}) }
     end
   end
+
+  describe 'variable type and content validations' do
+    mandatory_params = {}
+    validations = {
+      'boolean / stringified' => {
+        :name    => %w[do_not_reset_file_access_time use_ctime_for_incrementals],
+        :valid   => [true, 'true', false, 'false'],
+        :invalid => ['string', %w(array), { 'ha' => 'sh' }, 3, 2.42, nil],
+        :message => '(Unknown type of boolean given|Requires either string to work with)',
+      },
+    }
+
+    validations.sort.each do |type, var|
+      var[:name].each do |var_name|
+        var[:params] = {} if var[:params].nil?
+        var[:valid].each do |valid|
+          context "when #{var_name} (#{type}) is set to valid #{valid} (as #{valid.class})" do
+            let(:params) { [mandatory_params, var[:params], { :"#{var_name}" => valid, }].reduce(:merge) }
+            it { should compile }
+          end
+        end
+
+        var[:invalid].each do |invalid|
+          context "when #{var_name} (#{type}) is set to invalid #{invalid} (as #{invalid.class})" do
+            let(:params) { [mandatory_params, var[:params], { :"#{var_name}" => invalid, }].reduce(:merge) }
+            it 'should fail' do
+              expect { should contain_class(subject) }.to raise_error(Puppet::Error, /#{var[:message]}/)
+            end
+          end
+        end
+      end # var[:name].each
+    end # validations.sort.each
+  end # describe 'variable type and content validations'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,8 @@ RSpec.configure do |config|
     Facter.clear_messages
   end
   config.default_facts = {
-    :environment => 'rp_env',
+    :environment       => 'rp_env',
+    :osfamily          => 'RedHat',
+    :lsbmajdistrelease => '7',
   }
 end

--- a/templates/bp.conf.erb
+++ b/templates/bp.conf.erb
@@ -5,9 +5,5 @@ CLIENT_NAME = <%= @client_name %>
 <% @media_server_array.each do |media_server| -%>
 MEDIA_SERVER = <%= media_server %>
 <% end %>
-<% if @do_not_reset_file_access_time -%>
 DO_NOT_RESET_FILE_ACCESS_TIME = <%= @do_not_reset_file_access_time_string %>
-<% end -%>
-<% if @use_ctime_for_incrementals -%>
 USE_CTIME_FOR_INCREMENTALS = <%= @use_ctime_for_incrementals_string %>
-<% end -%>

--- a/templates/bp.conf.erb
+++ b/templates/bp.conf.erb
@@ -5,3 +5,9 @@ CLIENT_NAME = <%= @client_name %>
 <% @media_server_array.each do |media_server| -%>
 MEDIA_SERVER = <%= media_server %>
 <% end %>
+<% if @do_not_reset_file_access_time -%>
+DO_NOT_RESET_FILE_ACCESS_TIME = <%= @do_not_reset_file_access_time_string %>
+<% end -%>
+<% if @use_ctime_for_incrementals -%>
+USE_CTIME_FOR_INCREMENTALS = <%= @use_ctime_for_incrementals_string %>
+<% end -%>


### PR DESCRIPTION
By default if netbackup backups a file linux updates the ctime and atime
values of the file.
If you for different reasons don't want this to happen you can use
DO_NOT_RESET_FILE_ACCESS_TIME=YES
USE_CTIME_FOR_INCREMENTALS=YES
When nothing is defined in the config file the default is NO.